### PR TITLE
Fix race condition showing duplicate entries

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,6 +136,7 @@ class Indicator extends PanelMenu.Button {
 export default class InhibitionIndicatorExtension extends Extension {
     protected _settings: Gio.Settings | null = null;
     protected _indicator: Indicator | null = null;
+    protected _updateGeneration: number = 0;
 
     get settings() {
         return this._settings;
@@ -211,32 +212,36 @@ export default class InhibitionIndicatorExtension extends Extension {
     }
 
     async updateInhibitors() {
-        let objPaths;
+        const generation = ++this._updateGeneration;
+        
         try {
-            objPaths = await getInhibitorIds();
-            const inhibited = !!objPaths.length;
+            const objPaths = await getInhibitorIds();
+            
+            const promises = objPaths.map((objPath) =>
+                Promise.all([
+                    getInhibitorAppId(objPath),
+                    getInhibitorReason(objPath),
+                ]),
+            );
+            const settled = await Promise.allSettled(promises);
+            const inhibitors = settled
+                .filter(
+                    (r): r is PromiseFulfilledResult<[string, string]> =>
+                        r.status === "fulfilled",
+                )
+                .map((r) => r.value);
+            const inhibited = !!inhibitors.length;
 
-            if (!this._indicator) {
+            // No awaits past this point.
+            if (!this._indicator || generation !== this._updateGeneration) {
                 return;
             }
 
             this._indicator.updateStatus(inhibited);
             this._indicator.clearInhibitors();
-
-            if (inhibited) {
-                const promises = objPaths.map((objPath) =>
-                    Promise.all([
-                        getInhibitorAppId(objPath),
-                        getInhibitorReason(objPath),
-                    ]),
-                );
-                const inhibitors = await Promise.all(promises);
-                if (!this._indicator) {
-                    return;
-                }
-                for (const [appId, reason] of inhibitors) {
-                    this._indicator.addInhibitor(appId + ": " + reason);
-                }
+            
+            for (const [appId, reason] of inhibitors) {
+                this._indicator.addInhibitor(appId + ": " + reason);
             }
         } catch (e) {
             console.error(e);

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,7 +7,8 @@
         "46",
         "47",
         "48",
-        "49"
+        "49",
+        "50"
     ],
     "gettext-domain": "inhibitionindicator@monyxie.github.io",
     "url": "https://github.com/monyxie/inhibitionindicator",


### PR DESCRIPTION
Disclaimer: I used Claude/LLM to help with this.

After start playing a video with FreeTube app, I see the indicator showing the entries being duplicated, sometimes more than once.

<img width="478" height="408" alt="image" src="https://github.com/user-attachments/assets/c2bcf0be-9e27-4d18-bfe2-b3b92c1b00ed" />

It turns out that `updateInhibitors` can be called repeatedly (for some reason). In such case, all calls clear the inhibitors, but then each goes into await for getting `getInhibitorAppId` and `getInhibitorReason` data back. After that all calls can add their observed list of inhibitors to the list to display, hence the duplicate entries.

Also take the chance to bump Gnome shell version supported as I'm using this in Ubuntu 26.04 with Gnome 50.